### PR TITLE
Split extendRead() for ezc3d vs BTK

### DIFF
--- a/OpenSim/Common/C3DFileAdapter.cpp
+++ b/OpenSim/Common/C3DFileAdapter.cpp
@@ -90,18 +90,11 @@ C3DFileAdapter::OutputTables
 C3DFileAdapter::extendRead(const std::string& fileName) const {
 #ifdef WITH_EZC3D
     auto c3d = ezc3d::c3d(fileName);
-#else
-    auto reader = btk::AcquisitionFileReader::New();
-    reader->SetFilename(fileName);
-    reader->Update();
-    auto acquisition = reader->GetOutput();
-#endif
 
     EventTable event_table{};
-#ifdef WITH_EZC3D
     std::vector<std::string> eventDescription;
     if (c3d.parameters().isGroup("EVENT")
-            && c3d.parameters().group("EVENT").isParameter("DESCRIPTION")){
+        && c3d.parameters().group("EVENT").isParameter("DESCRIPTION")){
         eventDescription = c3d.parameters().group("EVENT")
                 .parameter("DESCRIPTION").valuesAsString();
     }
@@ -112,50 +105,23 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
             eventDescriptionStr = eventDescription[i];
         }
         event_table.push_back(
-        {
-            c3d.header().eventsLabel(i),
-            static_cast<double>(c3d.header().eventsTime(i)),
-            static_cast<int>(
-                        c3d.header().eventsTime(i) / c3d.header().frameRate()),
-            eventDescriptionStr
-        });
+                {
+                        c3d.header().eventsLabel(i),
+                        static_cast<double>(c3d.header().eventsTime(i)),
+                        static_cast<int>(
+                                c3d.header().eventsTime(i) / c3d.header().frameRate()),
+                        eventDescriptionStr
+                });
     }
-#else
-    auto events = acquisition->GetEvents();
-    for (auto it = events->Begin();
-        it != events->End();
-        ++it) {
-        auto et = *it;
-        event_table.push_back({ et->GetLabel(),
-            et->GetTime(),
-            et->GetFrame(),
-            et->GetDescription() });
-    }
-#endif
     OutputTables tables{};
 
-#ifdef WITH_EZC3D
     int numFrames(static_cast<int>(c3d.data().nbFrames()));
     int numMarkers(c3d.parameters().group("POINT")
-                  .parameter("USED").valuesAsInt()[0]);
+                           .parameter("USED").valuesAsInt()[0]);
     double pointFrequency(
-                static_cast<double>(
+            static_cast<double>(
                     c3d.parameters().group("POINT")
-                    .parameter("RATE").valuesAsDouble()[0]));
-#else
-    auto marker_pts = btk::PointCollection::New();
-
-    for(auto it = acquisition->BeginPoint();
-        it != acquisition->EndPoint();
-        ++it) {
-        auto pt = *it;
-        if(pt->GetType() == btk::Point::Marker)
-               marker_pts->InsertItem(pt);
-    }
-    int numFrames(marker_pts->GetFrontItem()->GetFrameNumber());
-    int numMarkers(marker_pts->GetItemNumber());
-    double pointFrequency(acquisition->GetPointFrequency());
-#endif
+                            .parameter("RATE").valuesAsDouble()[0]));
 
     if(numMarkers != 0) {
 
@@ -166,16 +132,10 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
         SimTK::Matrix_<SimTK::Vec3> marker_matrix(marker_nrow, marker_ncol);
 
         std::vector<std::string> marker_labels{};
-#ifdef WITH_EZC3D
         for (auto label : c3d.parameters().group("POINT")
-                          .parameter("LABELS").valuesAsString()) {
+                .parameter("LABELS").valuesAsString()) {
             marker_labels.push_back(SimTK::Value<std::string>(label));
         }
-#else
-        for (auto it = marker_pts->Begin(); it != marker_pts->End(); ++it) {
-            marker_labels.push_back(SimTK::Value<std::string>((*it)->GetLabel()));
-        }
-#endif
 
         double time_step{1.0 / pointFrequency};
         for(int f = 0; f < marker_nrow; ++f) {
@@ -187,7 +147,6 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
             // values as blank, instead of 0,  when exporting to .trc
             // See: C3D documention 3D Point Residuals
             // Read in value if it is not zero or residual is not -1
-#ifdef WITH_EZC3D
             for(auto pt : c3d.data().frame(f).points().points()) {
                 if (!pt.isEmpty() ) {//residual is not -1
                     row[m] = SimTK::Vec3{ static_cast<double>(pt.x()),
@@ -196,36 +155,22 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
                 }
                 ++m;
             }
-#else
-            for(auto it = marker_pts->Begin();  it != marker_pts->End(); ++it) {
-                // See: BTKCore/Code/IO/btkTRCFileIO.cpp#L359-L360
-                auto pt = *it;
-                if (!pt->GetValues().row(f).isZero() ||    //not precisely zero
-                    (pt->GetResiduals().coeff(f) != -1) ) {//residual is not -1
-                    row[m] = SimTK::Vec3{ pt->GetValues().coeff(f, 0),
-                                          pt->GetValues().coeff(f, 1),
-                                          pt->GetValues().coeff(f, 2) };
-                }
-                ++m;
-            }
-#endif
 
             marker_matrix.updRow(f) = row;
             marker_times[f] = 0 + f * time_step; //TODO: 0 should be start_time
         }
 
         // Create the data
-        auto marker_table = 
-            std::make_shared<TimeSeriesTableVec3>(marker_times, 
-                                                  marker_matrix, 
-                                                  marker_labels);
+        auto marker_table =
+                std::make_shared<TimeSeriesTableVec3>(marker_times,
+                                                      marker_matrix,
+                                                      marker_labels);
 
         marker_table->
-            updTableMetaData().
-            setValueForKey("DataRate",
-                std::to_string(pointFrequency));
+                updTableMetaData().
+                setValueForKey("DataRate",
+                               std::to_string(pointFrequency));
 
-#ifdef WITH_EZC3D
         const auto& units_param = c3d.parameters().group("POINT")
                 .parameter("UNITS").valuesAsString();
         std::string units;
@@ -235,9 +180,6 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
         else {
             units = "";
         }
-#else
-        std::string units = acquisition->GetPointUnit();
-#endif
         marker_table->updTableMetaData().setValueForKey("Units", units);
 
         marker_table->updTableMetaData().setValueForKey("events", event_table);
@@ -250,7 +192,7 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
         SimTK::Matrix_<SimTK::Vec3> noData;
         auto emptyMarkersTable =
                 std::make_shared<TimeSeriesTableVec3>(
-                    emptyTimes, noData, emptyLabels);
+                        emptyTimes, noData, emptyLabels);
         tables.emplace(_markers, emptyMarkersTable);
     }
 
@@ -258,12 +200,11 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
     std::vector<SimTK::Matrix_<double>> fpCorners{};
     std::vector<SimTK::Matrix_<double>> fpOrigins{};
     std::vector<unsigned>               fpTypes{};
-#ifdef WITH_EZC3D
     const auto& force_platforms_extractor = ezc3d::Modules::ForcePlatforms(c3d);
 
     ForceLocation forceLocation(getLocationForForceExpression());
     auto numPlatform(static_cast<int>(
-                         force_platforms_extractor.forcePlatforms().size()));
+                             force_platforms_extractor.forcePlatforms().size()));
 
     for (const auto& platform : force_platforms_extractor.forcePlatforms()){
 
@@ -271,57 +212,13 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
         const auto& corners   = platform.corners();
         const auto& origins   = platform.origin();
         auto type = platform.type();
-#else
-    // This is probably the right way to get the raw forces data from force 
-    // platforms. Extract the collection of force platforms.
-    auto force_platforms_extractor = btk::ForcePlatformsExtractor::New();
-    force_platforms_extractor->SetInput(acquisition);
-    auto force_platform_collection = force_platforms_extractor->GetOutput();
-    force_platforms_extractor->Update();
-
-    auto    fp_force_pts = btk::PointCollection::New();
-    auto   fp_moment_pts = btk::PointCollection::New();
-    auto fp_position_pts = btk::PointCollection::New();
-
-    for(auto platform = force_platform_collection->Begin();
-        platform != force_platform_collection->End();
-        ++platform) {
-        const auto& calMatrix = (*platform)->GetCalMatrix();
-        const auto& corners   = (*platform)->GetCorners();
-        const auto& origins   = (*platform)->GetOrigin();
-        auto type = (*platform)->GetType();
-#endif
 
         fpCalMatrices.push_back(convertToSimtkMatrix(calMatrix));
         fpCorners.push_back(convertToSimtkMatrix(corners));
         fpOrigins.push_back(convertToSimtkMatrix(origins));
         fpTypes.push_back(static_cast<unsigned>(type));
 
-#ifdef WITH_BTK
-        // Get ground reaction wrenches for the force platform.
-        auto ground_reaction_wrench_filter = 
-            btk::GroundReactionWrenchFilter::New();
-        ground_reaction_wrench_filter->setLocation(
-            btk::GroundReactionWrenchFilter::Location(getLocationForForceExpression()));
-        ground_reaction_wrench_filter->SetInput(*platform);
-        auto wrench_collection = ground_reaction_wrench_filter->GetOutput();
-        ground_reaction_wrench_filter->Update();
-        
-        for(auto wrench = wrench_collection->Begin();
-            wrench != wrench_collection->End(); 
-            ++wrench) {
-            // Forces time series.
-            fp_force_pts->InsertItem((*wrench)->GetForce());
-            // Moment time series.
-            fp_moment_pts->InsertItem((*wrench)->GetMoment());
-            // Position time series.
-            fp_position_pts->InsertItem((*wrench)->GetPosition());
-        }
-#endif
     }
-#ifdef WITH_BTK
-    auto numPlatform(fp_force_pts->GetItemNumber());
-#endif
 
     if(numPlatform != 0) {
         std::vector<std::string> labels{};
@@ -329,21 +226,12 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
         for(int fp = 1; fp <= numPlatform; ++fp) {
             auto fp_str = std::to_string(fp);
 
-#ifdef WITH_EZC3D
             auto force_unit =
                     force_platforms_extractor.forcePlatform(fp-1).forceUnit();
             auto position_unit =
                     force_platforms_extractor.forcePlatform(fp-1).positionUnit();
             auto moment_unit =
                     force_platforms_extractor.forcePlatform(fp-1).momentUnit();
-#else
-            auto force_unit = acquisition->GetPointUnits().
-                    at(_unit_index.at("force"));
-            auto position_unit = acquisition->GetPointUnits().
-                at(_unit_index.at("marker"));
-            auto moment_unit = acquisition->GetPointUnits().
-                at(_unit_index.at("moment"));
-#endif
 
             labels.push_back(SimTK::Value<std::string>("f" + fp_str));
             units.upd().push_back(SimTK::Value<std::string>(force_unit));
@@ -355,26 +243,20 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
             units.upd().push_back(SimTK::Value<std::string>(moment_unit));
         }
 
-#ifdef WITH_EZC3D
         const int nf = force_platforms_extractor.forcePlatform(0).nbFrames();
         auto analogFrequency = static_cast<double>(c3d.header().frameRate()
-                                            * c3d.header().nbAnalogByFrame());
+                                                   * c3d.header().nbAnalogByFrame());
         const auto& pf_ref(force_platforms_extractor.forcePlatforms());
-#else
-        const int nf = fp_force_pts->GetFrontItem()->GetFrameNumber();
-        auto analogFrequency = acquisition->GetAnalogFrequency();
-#endif
-        
+
         std::vector<double> force_times(nf);
         SimTK::Matrix_<SimTK::Vec3> force_matrix(nf, (int)labels.size());
 
         double time_step{1.0 / analogFrequency};
 
         for(int f = 0; f < nf;  ++f) {
-            SimTK::RowVector_<SimTK::Vec3> 
-                row{numPlatform * 3};
+            SimTK::RowVector_<SimTK::Vec3>
+                    row{numPlatform * 3};
             int col{0};
-#ifdef WITH_EZC3D
             for (size_t i=0; i<numPlatform; ++i){
                 row[col] = SimTK::Vec3{pf_ref[i].forces()[f](0),
                                        pf_ref[i].forces()[f](1),
@@ -404,7 +286,240 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
                                   "implemented for ezc3d files");
                 }
             }
-#else
+            force_matrix.updRow(f) = row;
+            force_times[f] = 0 + f * time_step; //TODO: 0 should be start_time
+        }
+
+        auto&  force_table =
+                *(new TimeSeriesTableVec3(force_times, force_matrix, labels));
+
+        TimeSeriesTableVec3::DependentsMetaData force_dep_metadata
+                = force_table.getDependentsMetaData();
+
+        // add units to the dependent meta data
+        force_dep_metadata.setValueArrayForKey("units", units);
+        force_table.setDependentsMetaData(force_dep_metadata);
+
+        force_table.
+                updTableMetaData().
+                setValueForKey("CalibrationMatrices", std::move(fpCalMatrices));
+
+        force_table.
+                updTableMetaData().
+                setValueForKey("Corners", std::move(fpCorners));
+
+        force_table.
+                updTableMetaData().
+                setValueForKey("Origins", std::move(fpOrigins));
+
+        force_table.
+                updTableMetaData().
+                setValueForKey("Types", std::move(fpTypes));
+
+        force_table.
+                updTableMetaData().
+                setValueForKey("DataRate",
+                               std::to_string(analogFrequency));
+
+        tables.emplace(_forces,
+                       std::shared_ptr<TimeSeriesTableVec3>(&force_table));
+
+        force_table.updTableMetaData().setValueForKey("events", event_table);
+    }
+    else { // insert empty table
+        std::vector<double> emptyTimes;
+        std::vector<std::string> emptyLabels;
+        SimTK::Matrix_<SimTK::Vec3> noData;
+        auto emptyforcesTable = std::make_shared<TimeSeriesTableVec3>(
+                emptyTimes, noData, emptyLabels);
+        tables.emplace(_forces, emptyforcesTable);
+    }
+    return tables;
+
+#else // WITH_BTK.
+    auto reader = btk::AcquisitionFileReader::New();
+    reader->SetFilename(fileName);
+    reader->Update();
+    auto acquisition = reader->GetOutput();
+
+    EventTable event_table{};
+    auto events = acquisition->GetEvents();
+    for (auto it = events->Begin();
+        it != events->End();
+        ++it) {
+        auto et = *it;
+        event_table.push_back({ et->GetLabel(),
+            et->GetTime(),
+            et->GetFrame(),
+            et->GetDescription() });
+    }
+    OutputTables tables{};
+
+    auto marker_pts = btk::PointCollection::New();
+
+    for(auto it = acquisition->BeginPoint();
+        it != acquisition->EndPoint();
+        ++it) {
+        auto pt = *it;
+        if(pt->GetType() == btk::Point::Marker)
+               marker_pts->InsertItem(pt);
+    }
+    int numFrames(marker_pts->GetFrontItem()->GetFrameNumber());
+    int numMarkers(marker_pts->GetItemNumber());
+    double pointFrequency(acquisition->GetPointFrequency());
+
+    if(numMarkers != 0) {
+
+        int marker_nrow = numFrames;
+        int marker_ncol = numMarkers;
+
+        std::vector<double> marker_times(marker_nrow);
+        SimTK::Matrix_<SimTK::Vec3> marker_matrix(marker_nrow, marker_ncol);
+
+        std::vector<std::string> marker_labels{};
+        for (auto it = marker_pts->Begin(); it != marker_pts->End(); ++it) {
+            marker_labels.push_back(SimTK::Value<std::string>((*it)->GetLabel()));
+        }
+
+        double time_step{1.0 / pointFrequency};
+        for(int f = 0; f < marker_nrow; ++f) {
+            SimTK::RowVector_<SimTK::Vec3> row{ numMarkers,
+                                                SimTK::Vec3(SimTK::NaN) };
+            int m{0};
+            // C3D standard is to read empty values as zero, but sets a
+            // "residual" value to -1 and it is how it knows to export these
+            // values as blank, instead of 0,  when exporting to .trc
+            // See: C3D documention 3D Point Residuals
+            // Read in value if it is not zero or residual is not -1
+            for(auto it = marker_pts->Begin();  it != marker_pts->End(); ++it) {
+                // See: BTKCore/Code/IO/btkTRCFileIO.cpp#L359-L360
+                auto pt = *it;
+                if (!pt->GetValues().row(f).isZero() ||    //not precisely zero
+                    (pt->GetResiduals().coeff(f) != -1) ) {//residual is not -1
+                    row[m] = SimTK::Vec3{ pt->GetValues().coeff(f, 0),
+                                          pt->GetValues().coeff(f, 1),
+                                          pt->GetValues().coeff(f, 2) };
+                }
+                ++m;
+            }
+
+            marker_matrix.updRow(f) = row;
+            marker_times[f] = 0 + f * time_step; //TODO: 0 should be start_time
+        }
+
+        // Create the data
+        auto marker_table = 
+            std::make_shared<TimeSeriesTableVec3>(marker_times, 
+                                                  marker_matrix, 
+                                                  marker_labels);
+
+        marker_table->
+            updTableMetaData().
+            setValueForKey("DataRate",
+                std::to_string(pointFrequency));
+
+        std::string units = acquisition->GetPointUnit();
+        marker_table->updTableMetaData().setValueForKey("Units", units);
+
+        marker_table->updTableMetaData().setValueForKey("events", event_table);
+
+        tables.emplace(_markers, marker_table);
+    }
+    else { // insert empty table
+        std::vector<double> emptyTimes;
+        std::vector<std::string> emptyLabels;
+        SimTK::Matrix_<SimTK::Vec3> noData;
+        auto emptyMarkersTable =
+                std::make_shared<TimeSeriesTableVec3>(
+                    emptyTimes, noData, emptyLabels);
+        tables.emplace(_markers, emptyMarkersTable);
+    }
+
+    std::vector<SimTK::Matrix_<double>> fpCalMatrices{};
+    std::vector<SimTK::Matrix_<double>> fpCorners{};
+    std::vector<SimTK::Matrix_<double>> fpOrigins{};
+    std::vector<unsigned>               fpTypes{};
+    // This is probably the right way to get the raw forces data from force
+    // platforms. Extract the collection of force platforms.
+    auto force_platforms_extractor = btk::ForcePlatformsExtractor::New();
+    force_platforms_extractor->SetInput(acquisition);
+    auto force_platform_collection = force_platforms_extractor->GetOutput();
+    force_platforms_extractor->Update();
+
+    auto    fp_force_pts = btk::PointCollection::New();
+    auto   fp_moment_pts = btk::PointCollection::New();
+    auto fp_position_pts = btk::PointCollection::New();
+
+    for(auto platform = force_platform_collection->Begin();
+        platform != force_platform_collection->End();
+        ++platform) {
+        const auto& calMatrix = (*platform)->GetCalMatrix();
+        const auto& corners   = (*platform)->GetCorners();
+        const auto& origins   = (*platform)->GetOrigin();
+        auto type = (*platform)->GetType();
+
+        fpCalMatrices.push_back(convertToSimtkMatrix(calMatrix));
+        fpCorners.push_back(convertToSimtkMatrix(corners));
+        fpOrigins.push_back(convertToSimtkMatrix(origins));
+        fpTypes.push_back(static_cast<unsigned>(type));
+
+        // Get ground reaction wrenches for the force platform.
+        auto ground_reaction_wrench_filter = 
+            btk::GroundReactionWrenchFilter::New();
+        ground_reaction_wrench_filter->setLocation(
+            btk::GroundReactionWrenchFilter::Location(getLocationForForceExpression()));
+        ground_reaction_wrench_filter->SetInput(*platform);
+        auto wrench_collection = ground_reaction_wrench_filter->GetOutput();
+        ground_reaction_wrench_filter->Update();
+        
+        for(auto wrench = wrench_collection->Begin();
+            wrench != wrench_collection->End(); 
+            ++wrench) {
+            // Forces time series.
+            fp_force_pts->InsertItem((*wrench)->GetForce());
+            // Moment time series.
+            fp_moment_pts->InsertItem((*wrench)->GetMoment());
+            // Position time series.
+            fp_position_pts->InsertItem((*wrench)->GetPosition());
+        }
+    }
+    auto numPlatform(fp_force_pts->GetItemNumber());
+
+    if(numPlatform != 0) {
+        std::vector<std::string> labels{};
+        ValueArray<std::string> units{};
+        for(int fp = 1; fp <= numPlatform; ++fp) {
+            auto fp_str = std::to_string(fp);
+
+            auto force_unit = acquisition->GetPointUnits().
+                    at(_unit_index.at("force"));
+            auto position_unit = acquisition->GetPointUnits().
+                at(_unit_index.at("marker"));
+            auto moment_unit = acquisition->GetPointUnits().
+                at(_unit_index.at("moment"));
+
+            labels.push_back(SimTK::Value<std::string>("f" + fp_str));
+            units.upd().push_back(SimTK::Value<std::string>(force_unit));
+
+            labels.push_back(SimTK::Value<std::string>("p" + fp_str));
+            units.upd().push_back(SimTK::Value<std::string>(position_unit));
+
+            labels.push_back(SimTK::Value<std::string>("m" + fp_str));
+            units.upd().push_back(SimTK::Value<std::string>(moment_unit));
+        }
+
+        const int nf = fp_force_pts->GetFrontItem()->GetFrameNumber();
+        auto analogFrequency = acquisition->GetAnalogFrequency();
+
+        std::vector<double> force_times(nf);
+        SimTK::Matrix_<SimTK::Vec3> force_matrix(nf, (int)labels.size());
+
+        double time_step{1.0 / analogFrequency};
+
+        for(int f = 0; f < nf;  ++f) {
+            SimTK::RowVector_<SimTK::Vec3> 
+                row{numPlatform * 3};
+            int col{0};
             for(auto fit = fp_force_pts->Begin(),
                 mit =     fp_moment_pts->Begin(),
                 pit =   fp_position_pts->Begin();
@@ -425,7 +540,6 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
                                        (*mit)->GetValues().coeff(f, 2)};
                 ++col;
             }
-#endif
             force_matrix.updRow(f) = row;
             force_times[f] = 0 + f * time_step; //TODO: 0 should be start_time
         }
@@ -470,10 +584,12 @@ C3DFileAdapter::extendRead(const std::string& fileName) const {
         std::vector<double> emptyTimes;
         std::vector<std::string> emptyLabels;
         SimTK::Matrix_<SimTK::Vec3> noData;
-        auto emptyforcesTable = std::make_shared<TimeSeriesTableVec3>(emptyTimes, noData, emptyLabels);
+        auto emptyforcesTable = std::make_shared<TimeSeriesTableVec3>(
+                emptyTimes, noData, emptyLabels);
         tables.emplace(_forces, emptyforcesTable);
     }
     return tables;
+#endif
 }
 
 void

--- a/OpenSim/Common/Test/testC3DFileAdapter.cpp
+++ b/OpenSim/Common/Test/testC3DFileAdapter.cpp
@@ -78,9 +78,9 @@ void test(const std::string filename) {
     using namespace std;
 
     // The walking C3D files included in this test should not take more
-    // than 40ms on most hardware. We make the max time 200ms to account
-    // for potentially slower CI machines.
-    const long long MaximumLoadTimeInNs = SimTK::secToNs(0.200);
+    // than 40ms (BTK) or 200ms (ezc3d) on most hardware.
+    // We make the max time 200ms to account for potentially slower CI machines.
+    const long long MaximumLoadTimeInNs = SimTK::secToNs(0.400);
     
     Stopwatch watch;
     C3DFileAdapter c3dFileAdapter{};


### PR DESCRIPTION
@carmichaelong @pariterre I thought we could just fully duplicate `extendRead()`. What do you think?